### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/.github/workflows/build_image_from_template.yml
+++ b/.github/workflows/build_image_from_template.yml
@@ -1,0 +1,33 @@
+name: Manual Build App Image From Template (Release)
+run-name: Manual Build App Image for "${{ github.event.repository.name }}"
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_version:
+        description: "Tag version to build image for"
+        required: false
+      enable_cve_checks:
+        description: "Enable CVE checks during image build"
+        required: false
+        type: boolean
+        default: true
+      skip_tag_check:
+        description: "Skip tag existence check before building image"
+        required: false
+        type: boolean
+        default: false
+      no_cache_requirements:
+        description: "Do not use cache for installing requirements"
+        required: false
+        type: boolean
+        default: false
+jobs:
+  build-image:
+    uses: supervisely-ecosystem/workflows/.github/workflows/build_image_from_template.yml@master
+    with:
+      image_name: "${{ github.event.repository.name }}"
+      tag_version: "${{ inputs.tag_version }}"
+      cve_checks: ${{ inputs.enable_cve_checks }}
+      skip_tag_check: ${{ inputs.skip_tag_check }}
+      no_cache_requirements: ${{ inputs.no_cache_requirements }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,15 @@ on:
       - main
       - master
 jobs:
+  build-image:
+    if: "!github.event.release.prerelease"
+    uses: supervisely-ecosystem/workflows/.github/workflows/build_image_from_template.yml@master
+    with:
+      image_name: "${{ github.event.repository.name }}"
+      cve_checks: true
   Supervisely-Release:
     if: "!github.event.release.prerelease"
+    needs: build-image
     uses: supervisely-ecosystem/workflows/.github/workflows/common.yml@master
     secrets:
       SUPERVISELY_DEV_API_TOKEN: "${{ secrets.SUPERVISELY_DEV_API_TOKEN }}"

--- a/config.json
+++ b/config.json
@@ -10,7 +10,7 @@
   ],
   "description": "label project images or objects using NN",
   "docker_image": "supervisely/base-py-sdk:6.73.564",
-  "instance_version": "6.9.22",
+  "instance_version": "6.15.60",
   "entrypoint": "python -m uvicorn src.main:g.app --host 0.0.0.0 --port 8000",
   "port": 8000,
   "task_location": "workspace_tasks",

--- a/config.json
+++ b/config.json
@@ -9,7 +9,7 @@
     "inference interfaces"
   ],
   "description": "label project images or objects using NN",
-  "docker_image": "supervisely/base-py-sdk:6.73.112",
+  "docker_image": "supervisely/base-py-sdk:6.73.564",
   "instance_version": "6.9.22",
   "entrypoint": "python -m uvicorn src.main:g.app --host 0.0.0.0 --port 8000",
   "port": 8000,

--- a/config.json
+++ b/config.json
@@ -9,7 +9,7 @@
     "inference interfaces"
   ],
   "description": "label project images or objects using NN",
-  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
+  "docker_image": "supervisely/apply-classification-model-to-project:6.73.564",
   "instance_version": "6.15.60",
   "entrypoint": "python -m uvicorn src.main:g.app --host 0.0.0.0 --port 8000",
   "port": 8000,

--- a/config.json
+++ b/config.json
@@ -9,7 +9,7 @@
     "inference interfaces"
   ],
   "description": "label project images or objects using NN",
-  "docker_image": "supervisely/base-py-sdk:6.73.564",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
   "instance_version": "6.15.60",
   "entrypoint": "python -m uvicorn src.main:g.app --host 0.0.0.0 --port 8000",
   "port": 8000,

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,2 @@
 supervisely==6.73.564
+scipy==1.17.1

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.73.112
+supervisely==6.73.564

--- a/src/preferences/functions.py
+++ b/src/preferences/functions.py
@@ -102,17 +102,47 @@ def get_tags_list_for_predictions(predictions_row):
     return tags_list
 
 
+def unwrap_predictions_response(predictions):
+    if not isinstance(predictions, dict):
+        return predictions
+
+    for key in ("predictions", "results", "result", "outputs", "output"):
+        if key in predictions:
+            return predictions[key]
+
+    return predictions
+
+
+def get_prediction_from_response(predictions, index, row):
+    predictions = unwrap_predictions_response(predictions)
+
+    if isinstance(predictions, (list, tuple)):
+        if index < len(predictions):
+            return predictions[index]
+        return None
+
+    if isinstance(predictions, dict):
+        image_info = row[0] if isinstance(row, (list, tuple)) else row
+        possible_keys = (index, str(index), image_info.id, str(image_info.id))
+        for key in possible_keys:
+            if key in predictions:
+                return predictions[key]
+
+    return None
+
+
 def add_predicted_tags_to_labels(labels_batch, predictions):
     updated_labels = []
 
     for index, row in enumerate(labels_batch):
         label: sly.Label = row[1]
+        prediction = get_prediction_from_response(predictions, index, row)
 
-        if predictions[index] is None:
+        if prediction is None:
             sly.logger.warning(f'cannot read prediction for label {row}')
             continue
 
-        tags_list = get_tags_list_for_predictions(predictions[index])
+        tags_list = get_tags_list_for_predictions(prediction)
 
         updated_labels.append(label.clone(tags=sly.TagCollection(tags_list)))
 
@@ -123,12 +153,13 @@ def get_predicted_tags_for_images(labels_batch, predictions):
     predicted_tags_collections = []
 
     for index, row in enumerate(labels_batch):
+        prediction = get_prediction_from_response(predictions, index, row)
 
-        if predictions[index] is None:
+        if prediction is None:
             sly.logger.warning(f'cannot read prediction for label {row}')
             continue
 
-        tags_list = get_tags_list_for_predictions(predictions[index])
+        tags_list = get_tags_list_for_predictions(prediction)
         predicted_tags_collections.append(sly.TagCollection(tags_list))
 
     return predicted_tags_collections


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
